### PR TITLE
ZCS-1428: TestSSDBEphemeralStore updates

### DIFF
--- a/src/java/com/zimbra/qa/unittest/TestSSDBEphemeralStore.java
+++ b/src/java/com/zimbra/qa/unittest/TestSSDBEphemeralStore.java
@@ -42,9 +42,12 @@ public class TestSSDBEphemeralStore extends TestCase {
         String ssdbUrl = Provisioning.getInstance().getConfig().getEphemeralBackendURL();
         String toks[] = ssdbUrl.split(":");
         if(toks != null && toks.length == 3 && "ssdb".equalsIgnoreCase(toks[0])) {
-            SSDBStoreConfigured = true;
             EphemeralStore.setFactory(SSDBEphemeralStore.Factory.class);
-            store = SSDBEphemeralStore.getFactory().getStore();
+            EphemeralStore.Factory factory = EphemeralStore.getFactory();
+            factory.test(ssdbUrl);
+            store = factory.getStore();
+            assertTrue(store instanceof SSDBEphemeralStore);
+            SSDBStoreConfigured = true;
         } else {
             SSDBStoreConfigured = false;
         }

--- a/src/java/com/zimbra/qa/unittest/TestSSDBEphemeralStore.java
+++ b/src/java/com/zimbra/qa/unittest/TestSSDBEphemeralStore.java
@@ -1,5 +1,7 @@
 package com.zimbra.qa.unittest;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import junit.framework.TestCase;
@@ -11,6 +13,7 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.Pair;
 import com.zimbra.cs.account.Config;
 import com.zimbra.cs.account.Provisioning;
 import com.zimbra.cs.account.soap.SoapProvisioning;
@@ -36,6 +39,7 @@ public class TestSSDBEphemeralStore extends TestCase {
     private String SAMPLE_AUTH_TOKEN_VERSION = "8.7.0_GA_1659";
     private String ACCOUNT_ID = "47e456be-b00a-465e-a1db-4b53e64fa";
     private boolean SSDBStoreConfigured = false;
+    private List<Pair<EphemeralInput, EphemeralLocation>> toDelete = new ArrayList<Pair<EphemeralInput, EphemeralLocation>>();
 
     @Override
     public void setUp() throws Exception {
@@ -56,19 +60,32 @@ public class TestSSDBEphemeralStore extends TestCase {
     @Override
     public void tearDown() throws Exception {
         if (SSDBStoreConfigured) {
-            String ssdbUrl = Provisioning.getInstance().getConfig().getEphemeralBackendURL();
-            String toks[] = ssdbUrl.split(":");
-            SSDBEphemeralStore.getFactory().shutdown();
-            try {
-                try(JedisPool pool = new JedisPool(toks[1], Integer.parseInt(toks[2]))) {
-                    try (Jedis jedis = pool.getResource()) {
-                        jedis.flushDB();
-                    }
+            for (Pair<EphemeralInput, EphemeralLocation> pair: toDelete) {
+                EphemeralInput input = pair.getFirst();
+                EphemeralLocation location = pair.getSecond();
+                try {
+                    store.delete(input.getEphemeralKey(), (String) input.getValue(), location);
+                } catch (ServiceException e) {
+                    // ignore failed deletions
                 }
-            } catch (ClassCastException e) {
-                //ignore
             }
+            toDelete.clear();
+            SSDBEphemeralStore.getFactory().shutdown();
         }
+    }
+
+    private void addDeletionEntry(EphemeralInput input, EphemeralLocation location) {
+        toDelete.add(new Pair<EphemeralInput, EphemeralLocation>(input, location));
+    }
+
+    private void doSet(EphemeralInput input, EphemeralLocation location) throws ServiceException {
+        store.set(input, location);
+        addDeletionEntry(input, location);
+    }
+
+    private void doUpdate(EphemeralInput input, EphemeralLocation location) throws ServiceException {
+        store.update(input, location);
+        addDeletionEntry(input, location);
     }
 
     @Test
@@ -81,8 +98,7 @@ public class TestSSDBEphemeralStore extends TestCase {
         };
         EphemeralKey eKey = new EphemeralKey(Provisioning.A_zimbraLastLogonTimestamp);
         EphemeralInput attr = new EphemeralInput(eKey, firstLogin);
-        store.set(attr, accountIDLocation);
-
+        doSet(attr, accountIDLocation);
         EphemeralResult retAttr = store.get(eKey, accountIDLocation);
         assertNotNull(retAttr);
         assertEquals("Found incorrect last logon timestamp value",firstLogin, retAttr.getValue());
@@ -100,8 +116,8 @@ public class TestSSDBEphemeralStore extends TestCase {
         EphemeralKey eKey = new EphemeralKey(Provisioning.A_zimbraLastLogonTimestamp);
         EphemeralInput attr = new EphemeralInput(eKey, firstLogin);
         EphemeralInput attrLatest = new EphemeralInput(eKey, lastLogin);
-        store.set(attr, accountIDLocation);
-        store.set(attrLatest, accountIDLocation);
+        doSet(attr, accountIDLocation);
+        doSet(attrLatest, accountIDLocation);
         EphemeralResult retAttr = store.get(eKey, accountIDLocation);
         assertNotNull(retAttr);
         assertEquals("Found incorrect last logon timestamp value",lastLogin, retAttr.getValue());
@@ -119,8 +135,8 @@ public class TestSSDBEphemeralStore extends TestCase {
         EphemeralKey eKey = new EphemeralKey(Provisioning.A_zimbraLastLogonTimestamp);
         EphemeralInput attr = new EphemeralInput(eKey, firstLogin);
         EphemeralInput attrLatest = new EphemeralInput(eKey, lastLogin);
-        store.set(attr, accountIDLocation);
-        store.update(attrLatest, accountIDLocation);
+        doSet(attr, accountIDLocation);
+        doUpdate(attrLatest, accountIDLocation);
         EphemeralResult retAttr = store.get(eKey, accountIDLocation);
         assertNotNull(retAttr);
         assertEquals("Found incorrect last logon timestamp value", lastLogin, retAttr.getValue());
@@ -135,7 +151,7 @@ public class TestSSDBEphemeralStore extends TestCase {
         };
         EphemeralKey eKey = new EphemeralKey(Provisioning.A_zimbraAuthTokens, SAMPLE_AUTH_TOKEN);
         EphemeralInput attr = new EphemeralInput(eKey, SAMPLE_AUTH_TOKEN_VERSION);
-        store.set(attr, accountIDLocation);
+        doSet(attr, accountIDLocation);
         assertTrue("Should find this auth token", store.has(eKey, accountIDLocation));
     }
 
@@ -149,7 +165,7 @@ public class TestSSDBEphemeralStore extends TestCase {
         EphemeralKey eKey = new EphemeralKey(Provisioning.A_zimbraAuthTokens, SAMPLE_AUTH_TOKEN);
         EphemeralKey eKey2 = new EphemeralKey(Provisioning.A_zimbraAuthTokens, SAMPLE_AUTH_TOKEN2);
         EphemeralInput attr = new EphemeralInput(eKey, SAMPLE_AUTH_TOKEN_VERSION);
-        store.set(attr, accountIDLocation);
+        doSet(attr, accountIDLocation);
         assertFalse("should not find this auth token ", store.has(eKey2, accountIDLocation));
     }
 
@@ -163,7 +179,7 @@ public class TestSSDBEphemeralStore extends TestCase {
         };
         EphemeralKey eKey = new EphemeralKey(Provisioning.A_zimbraCsrfTokenData, SAMPLE_CSRF_TOKEN_CRUMB);
         EphemeralInput attr = new EphemeralInput(eKey, SAMPLE_CSRF_TOKEN_DATA);
-        store.set(attr, accountIDLocation);
+        doSet(attr, accountIDLocation);
         assertTrue("Should find this CSRF token crumb", store.has(eKey, accountIDLocation));
     }
 
@@ -177,7 +193,7 @@ public class TestSSDBEphemeralStore extends TestCase {
         EphemeralKey eKey1 = new EphemeralKey(Provisioning.A_zimbraCsrfTokenData, SAMPLE_CSRF_TOKEN_CRUMB);
         EphemeralKey eKey2 = new EphemeralKey(Provisioning.A_zimbraCsrfTokenData, SAMPLE_CSRF_TOKEN_CRUMB2);
         EphemeralInput attr = new EphemeralInput(eKey1, SAMPLE_CSRF_TOKEN_DATA);
-        store.set(attr, accountIDLocation);
+        doSet(attr, accountIDLocation);
         assertFalse("should not find this CSRF token crumb ", store.has(eKey2, accountIDLocation));
     }
 
@@ -191,8 +207,8 @@ public class TestSSDBEphemeralStore extends TestCase {
         EphemeralKey eKey = new EphemeralKey(Provisioning.A_zimbraCsrfTokenData, SAMPLE_CSRF_TOKEN_CRUMB);
         EphemeralInput attr = new EphemeralInput(eKey, SAMPLE_CSRF_TOKEN_DATA);
         EphemeralInput updatedAttr = new EphemeralInput(eKey, SAMPLE_CSRF_TOKEN_DATA2);
-        store.set(attr, accountIDLocation);
-        store.set(updatedAttr, accountIDLocation);
+        doSet(attr, accountIDLocation);
+        doSet(updatedAttr, accountIDLocation);
         assertTrue("Should find the CSRF token crumb that was just saved", store.has(eKey, accountIDLocation));
         assertEquals(SAMPLE_CSRF_TOKEN_DATA2, store.get(eKey, accountIDLocation).getValue());
     }
@@ -212,9 +228,9 @@ public class TestSSDBEphemeralStore extends TestCase {
         EphemeralInput attrVal2 = new EphemeralInput(eKey2, SAMPLE_CSRF_TOKEN_DATA2);
         EphemeralInput attrVal3 = new EphemeralInput(eKey3, SAMPLE_CSRF_TOKEN_DATA3);
 
-        store.set(attrVal1, accountIDLocation);
-        store.set(attrVal2, accountIDLocation);
-        store.set(attrVal3, accountIDLocation);
+        doSet(attrVal1, accountIDLocation);
+        doSet(attrVal2, accountIDLocation);
+        doSet(attrVal3, accountIDLocation);
 
         assertTrue(store.has(eKey1, accountIDLocation));
         assertTrue(store.has(eKey2, accountIDLocation));
@@ -240,9 +256,9 @@ public class TestSSDBEphemeralStore extends TestCase {
         EphemeralInput attrVal2 = new EphemeralInput(eKey2, SAMPLE_AUTH_TOKEN_VERSION);
         EphemeralInput attrVal3 = new EphemeralInput(eKey3, SAMPLE_AUTH_TOKEN_VERSION);
 
-        store.set(attrVal1, accountIDLocation);
-        store.set(attrVal2, accountIDLocation);
-        store.set(attrVal3, accountIDLocation);
+        doSet(attrVal1, accountIDLocation);
+        doSet(attrVal2, accountIDLocation);
+        doSet(attrVal3, accountIDLocation);
 
         assertTrue(store.has(eKey1, accountIDLocation));
         assertTrue(store.has(eKey2, accountIDLocation));
@@ -263,7 +279,7 @@ public class TestSSDBEphemeralStore extends TestCase {
         EphemeralKey eKey1 = new EphemeralKey(Provisioning.A_zimbraAuthTokens, SAMPLE_AUTH_TOKEN);
         RelativeExpiration exp = new RelativeExpiration(1000L, TimeUnit.MILLISECONDS);
         EphemeralInput attrVal1 = new EphemeralInput(eKey1, SAMPLE_AUTH_TOKEN_VERSION, exp);
-        store.set(attrVal1, accountIDLocation);
+        doSet(attrVal1, accountIDLocation);
         assertTrue("Token should be in SSDB before it expires", store.has(eKey1, accountIDLocation));
         Thread.sleep(2000);
         assertFalse("Token should be gone after 2 seconds", store.has(eKey1, accountIDLocation));
@@ -279,7 +295,7 @@ public class TestSSDBEphemeralStore extends TestCase {
         EphemeralKey eKey1 = new EphemeralKey(Provisioning.A_zimbraAuthTokens, SAMPLE_AUTH_TOKEN);
         RelativeExpiration exp = new RelativeExpiration(600000L, TimeUnit.MILLISECONDS);
         EphemeralInput attrVal1 = new EphemeralInput(eKey1, SAMPLE_AUTH_TOKEN_VERSION, exp);
-        store.set(attrVal1, accountIDLocation);
+        doSet(attrVal1, accountIDLocation);
         assertTrue("Token should be in SSDB after insertion", store.has(eKey1, accountIDLocation));
         store.delete(eKey1, SAMPLE_AUTH_TOKEN_VERSION, accountIDLocation);
         assertFalse("Token should be gone from SSDB after deletion", store.has(eKey1, accountIDLocation));
@@ -295,7 +311,7 @@ public class TestSSDBEphemeralStore extends TestCase {
         };
         EphemeralKey eKey = new EphemeralKey(Provisioning.A_zimbraLastLogonTimestamp);
         EphemeralInput attr = new EphemeralInput(eKey, lastLogon);
-        store.set(attr, accountIDLocation);
+        doSet(attr, accountIDLocation);
         assertTrue("Last logon value should be present before deletion", store.has(eKey, accountIDLocation));
         store.delete(eKey, lastLogon, accountIDLocation);
         assertFalse("Last logon value should be gone after deletion", store.has(eKey, accountIDLocation));

--- a/src/java/com/zimbra/qa/unittest/TestSSDBEphemeralStore.java
+++ b/src/java/com/zimbra/qa/unittest/TestSSDBEphemeralStore.java
@@ -55,18 +55,19 @@ public class TestSSDBEphemeralStore extends TestCase {
 
     @Override
     public void tearDown() throws Exception {
-        Assume.assumeTrue(SSDBStoreConfigured);
-        String ssdbUrl = Provisioning.getInstance().getConfig().getEphemeralBackendURL();
-        String toks[] = ssdbUrl.split(":");
-        SSDBEphemeralStore.getFactory().shutdown();
-        try {
-            try(JedisPool pool = new JedisPool(toks[1], Integer.parseInt(toks[2]))) {
-                try (Jedis jedis = pool.getResource()) {
-                    jedis.flushDB();
+        if (SSDBStoreConfigured) {
+            String ssdbUrl = Provisioning.getInstance().getConfig().getEphemeralBackendURL();
+            String toks[] = ssdbUrl.split(":");
+            SSDBEphemeralStore.getFactory().shutdown();
+            try {
+                try(JedisPool pool = new JedisPool(toks[1], Integer.parseInt(toks[2]))) {
+                    try (Jedis jedis = pool.getResource()) {
+                        jedis.flushDB();
+                    }
                 }
+            } catch (ClassCastException e) {
+                //ignore
             }
-        } catch (ClassCastException e) {
-            //ignore
         }
     }
 

--- a/src/java/com/zimbra/qa/unittest/TestSSDBEphemeralStore.java
+++ b/src/java/com/zimbra/qa/unittest/TestSSDBEphemeralStore.java
@@ -72,8 +72,6 @@ public class TestSSDBEphemeralStore extends TestCase {
     public void testSetGetLastLogin() throws Exception {
         Assume.assumeTrue(SSDBStoreConfigured);
         String firstLogin = "20160912212057.178Z";
-        EphemeralStore store = SSDBEphemeralStore.getFactory().getStore();
-        assertTrue(store instanceof SSDBEphemeralStore);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account", ACCOUNT_ID }; }
@@ -92,8 +90,6 @@ public class TestSSDBEphemeralStore extends TestCase {
         Assume.assumeTrue(SSDBStoreConfigured);
         String firstLogin = "20160912212057.178Z";
         String lastLogin = "20160912220045.178Z";
-        EphemeralStore store = SSDBEphemeralStore.getFactory().getStore();
-        assertTrue(store instanceof SSDBEphemeralStore);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account", ACCOUNT_ID }; }
@@ -113,8 +109,6 @@ public class TestSSDBEphemeralStore extends TestCase {
         Assume.assumeTrue(SSDBStoreConfigured);
         String firstLogin = "20160912212057.178Z";
         String lastLogin = "20160912220045.178Z";
-        EphemeralStore store = SSDBEphemeralStore.getFactory().getStore();
-        assertTrue(store instanceof SSDBEphemeralStore);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account", ACCOUNT_ID }; }
@@ -132,8 +126,6 @@ public class TestSSDBEphemeralStore extends TestCase {
     @Test
     public void testHasValidAuthToken() throws Exception {
         Assume.assumeTrue(SSDBStoreConfigured);
-        EphemeralStore store = SSDBEphemeralStore.getFactory().getStore();
-        assertTrue(store instanceof SSDBEphemeralStore);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account", ACCOUNT_ID }; }
@@ -147,8 +139,6 @@ public class TestSSDBEphemeralStore extends TestCase {
     @Test
     public void testHasInvalidAuthToken() throws Exception {
         Assume.assumeTrue(SSDBStoreConfigured);
-        EphemeralStore store = SSDBEphemeralStore.getFactory().getStore();
-        assertTrue(store instanceof SSDBEphemeralStore);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account", ACCOUNT_ID }; }
@@ -164,8 +154,6 @@ public class TestSSDBEphemeralStore extends TestCase {
     @Test
     public void testHasValidCsrfToken() throws Exception {
         Assume.assumeTrue(SSDBStoreConfigured);
-        EphemeralStore store = SSDBEphemeralStore.getFactory().getStore();
-        assertTrue(store instanceof SSDBEphemeralStore);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account",  ACCOUNT_ID}; }
@@ -179,8 +167,6 @@ public class TestSSDBEphemeralStore extends TestCase {
     @Test
     public void testHasInvalidCsrfToken() throws Exception {
         Assume.assumeTrue(SSDBStoreConfigured);
-        EphemeralStore store = SSDBEphemeralStore.getFactory().getStore();
-        assertTrue(store instanceof SSDBEphemeralStore);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account",  ACCOUNT_ID}; }
@@ -195,8 +181,6 @@ public class TestSSDBEphemeralStore extends TestCase {
     @Test
     public void testUpdateCsrfToken() throws Exception {
         Assume.assumeTrue(SSDBStoreConfigured);
-        EphemeralStore store = SSDBEphemeralStore.getFactory().getStore();
-        assertTrue(store instanceof SSDBEphemeralStore);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account",  ACCOUNT_ID}; }
@@ -213,8 +197,6 @@ public class TestSSDBEphemeralStore extends TestCase {
     @Test
     public void testMultipleCsrfTokens() throws Exception {
         Assume.assumeTrue(SSDBStoreConfigured);
-        EphemeralStore store = SSDBEphemeralStore.getFactory().getStore();
-        assertTrue(store instanceof SSDBEphemeralStore);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account",  ACCOUNT_ID}; }
@@ -243,8 +225,6 @@ public class TestSSDBEphemeralStore extends TestCase {
     @Test
     public void testMultipleAuthTokens() throws Exception {
         Assume.assumeTrue(SSDBStoreConfigured);
-        EphemeralStore store = SSDBEphemeralStore.getFactory().getStore();
-        assertTrue(store instanceof SSDBEphemeralStore);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account",  ACCOUNT_ID}; }
@@ -273,8 +253,6 @@ public class TestSSDBEphemeralStore extends TestCase {
     @Test
     public void testAuthTokenExpiration() throws Exception {
         Assume.assumeTrue(SSDBStoreConfigured);
-        EphemeralStore store = SSDBEphemeralStore.getFactory().getStore();
-        assertTrue(store instanceof SSDBEphemeralStore);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account",  ACCOUNT_ID}; }
@@ -291,8 +269,6 @@ public class TestSSDBEphemeralStore extends TestCase {
     @Test
     public void testDeleteAuthToken() throws Exception {
         Assume.assumeTrue(SSDBStoreConfigured);
-        EphemeralStore store = SSDBEphemeralStore.getFactory().getStore();
-        assertTrue(store instanceof SSDBEphemeralStore);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account",  ACCOUNT_ID}; }
@@ -310,8 +286,6 @@ public class TestSSDBEphemeralStore extends TestCase {
     public void testDeleteLastLogon() throws Exception {
         Assume.assumeTrue(SSDBStoreConfigured);
         String lastLogon = "20160912212057.178Z";
-        EphemeralStore store = SSDBEphemeralStore.getFactory().getStore();
-        assertTrue(store instanceof SSDBEphemeralStore);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account",  ACCOUNT_ID}; }

--- a/src/java/com/zimbra/qa/unittest/TestSSDBEphemeralStore.java
+++ b/src/java/com/zimbra/qa/unittest/TestSSDBEphemeralStore.java
@@ -45,7 +45,6 @@ public class TestSSDBEphemeralStore extends TestCase {
             SSDBStoreConfigured = true;
             EphemeralStore.setFactory(SSDBEphemeralStore.Factory.class);
             store = SSDBEphemeralStore.getFactory().getStore();
-            SSDBEphemeralStore.getFactory().startup();
         } else {
             SSDBStoreConfigured = false;
         }

--- a/src/java/com/zimbra/qa/unittest/TestSSDBEphemeralStore.java
+++ b/src/java/com/zimbra/qa/unittest/TestSSDBEphemeralStore.java
@@ -9,9 +9,6 @@ import junit.framework.TestCase;
 import org.junit.Assume;
 import org.junit.Test;
 
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPool;
-
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.Pair;
 import com.zimbra.cs.account.Config;
@@ -50,10 +47,8 @@ public class TestSSDBEphemeralStore extends TestCase {
             EphemeralStore.Factory factory = EphemeralStore.getFactory();
             factory.test(ssdbUrl);
             store = factory.getStore();
-            assertTrue(store instanceof SSDBEphemeralStore);
+            assertTrue("EphemeralStore should be an instance of SSDBEPhemeralStore", store instanceof SSDBEphemeralStore);
             SSDBStoreConfigured = true;
-        } else {
-            SSDBStoreConfigured = false;
         }
     }
 
@@ -90,7 +85,7 @@ public class TestSSDBEphemeralStore extends TestCase {
 
     @Test
     public void testSetGetLastLogin() throws Exception {
-        Assume.assumeTrue(SSDBStoreConfigured);
+        TestUtil.assumeTrue("SSDB backend is not configured", SSDBStoreConfigured);
         String firstLogin = "20160912212057.178Z";
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
@@ -100,13 +95,13 @@ public class TestSSDBEphemeralStore extends TestCase {
         EphemeralInput attr = new EphemeralInput(eKey, firstLogin);
         doSet(attr, accountIDLocation);
         EphemeralResult retAttr = store.get(eKey, accountIDLocation);
-        assertNotNull(retAttr);
+        assertNotNull("Last logon timestamp should not be null", retAttr);
         assertEquals("Found incorrect last logon timestamp value",firstLogin, retAttr.getValue());
     }
 
     @Test
     public void testSetGetOverwriteLastLogin() throws Exception {
-        Assume.assumeTrue(SSDBStoreConfigured);
+        TestUtil.assumeTrue("SSDB backend is not configured", SSDBStoreConfigured);
         String firstLogin = "20160912212057.178Z";
         String lastLogin = "20160912220045.178Z";
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
@@ -119,13 +114,13 @@ public class TestSSDBEphemeralStore extends TestCase {
         doSet(attr, accountIDLocation);
         doSet(attrLatest, accountIDLocation);
         EphemeralResult retAttr = store.get(eKey, accountIDLocation);
-        assertNotNull(retAttr);
+        assertNotNull("Last logon timestamp should not be null", retAttr);
         assertEquals("Found incorrect last logon timestamp value",lastLogin, retAttr.getValue());
     }
 
     @Test
     public void testSetUpdateLastLogin() throws Exception {
-        Assume.assumeTrue(SSDBStoreConfigured);
+        TestUtil.assumeTrue("SSDB backend is not configured", SSDBStoreConfigured);
         String firstLogin = "20160912212057.178Z";
         String lastLogin = "20160912220045.178Z";
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
@@ -138,13 +133,13 @@ public class TestSSDBEphemeralStore extends TestCase {
         doSet(attr, accountIDLocation);
         doUpdate(attrLatest, accountIDLocation);
         EphemeralResult retAttr = store.get(eKey, accountIDLocation);
-        assertNotNull(retAttr);
+        assertNotNull("Last logon timestamp should not be null", retAttr);
         assertEquals("Found incorrect last logon timestamp value", lastLogin, retAttr.getValue());
     }
 
     @Test
     public void testHasValidAuthToken() throws Exception {
-        Assume.assumeTrue(SSDBStoreConfigured);
+        TestUtil.assumeTrue("SSDB backend is not configured", SSDBStoreConfigured);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account", ACCOUNT_ID }; }
@@ -157,7 +152,7 @@ public class TestSSDBEphemeralStore extends TestCase {
 
     @Test
     public void testHasInvalidAuthToken() throws Exception {
-        Assume.assumeTrue(SSDBStoreConfigured);
+        TestUtil.assumeTrue("SSDB backend is not configured", SSDBStoreConfigured);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account", ACCOUNT_ID }; }
@@ -172,7 +167,7 @@ public class TestSSDBEphemeralStore extends TestCase {
 
     @Test
     public void testHasValidCsrfToken() throws Exception {
-        Assume.assumeTrue(SSDBStoreConfigured);
+        TestUtil.assumeTrue("SSDB backend is not configured", SSDBStoreConfigured);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account",  ACCOUNT_ID}; }
@@ -185,7 +180,7 @@ public class TestSSDBEphemeralStore extends TestCase {
 
     @Test
     public void testHasInvalidCsrfToken() throws Exception {
-        Assume.assumeTrue(SSDBStoreConfigured);
+        TestUtil.assumeTrue("SSDB backend is not configured", SSDBStoreConfigured);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account",  ACCOUNT_ID}; }
@@ -199,7 +194,7 @@ public class TestSSDBEphemeralStore extends TestCase {
 
     @Test
     public void testUpdateCsrfToken() throws Exception {
-        Assume.assumeTrue(SSDBStoreConfigured);
+        TestUtil.assumeTrue("SSDB backend is not configured", SSDBStoreConfigured);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account",  ACCOUNT_ID}; }
@@ -215,7 +210,7 @@ public class TestSSDBEphemeralStore extends TestCase {
 
     @Test
     public void testMultipleCsrfTokens() throws Exception {
-        Assume.assumeTrue(SSDBStoreConfigured);
+        TestUtil.assumeTrue("SSDB backend is not configured", SSDBStoreConfigured);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account",  ACCOUNT_ID}; }
@@ -232,9 +227,9 @@ public class TestSSDBEphemeralStore extends TestCase {
         doSet(attrVal2, accountIDLocation);
         doSet(attrVal3, accountIDLocation);
 
-        assertTrue(store.has(eKey1, accountIDLocation));
-        assertTrue(store.has(eKey2, accountIDLocation));
-        assertTrue(store.has(eKey3, accountIDLocation));
+        assertTrue(String.format("Token data for crumb %s not found", SAMPLE_CSRF_TOKEN_CRUMB), store.has(eKey1, accountIDLocation));
+        assertTrue(String.format("Token data for crumb %s not found", SAMPLE_CSRF_TOKEN_CRUMB2), store.has(eKey2, accountIDLocation));
+        assertTrue(String.format("Token data for crumb %s not found", SAMPLE_CSRF_TOKEN_CRUMB3), store.has(eKey3, accountIDLocation));
 
         assertEquals(SAMPLE_CSRF_TOKEN_DATA, store.get(eKey1, accountIDLocation).getValue());
         assertEquals(SAMPLE_CSRF_TOKEN_DATA2, store.get(eKey2, accountIDLocation).getValue());
@@ -243,7 +238,7 @@ public class TestSSDBEphemeralStore extends TestCase {
 
     @Test
     public void testMultipleAuthTokens() throws Exception {
-        Assume.assumeTrue(SSDBStoreConfigured);
+        TestUtil.assumeTrue("SSDB backend is not configured", SSDBStoreConfigured);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account",  ACCOUNT_ID}; }
@@ -260,9 +255,9 @@ public class TestSSDBEphemeralStore extends TestCase {
         doSet(attrVal2, accountIDLocation);
         doSet(attrVal3, accountIDLocation);
 
-        assertTrue(store.has(eKey1, accountIDLocation));
-        assertTrue(store.has(eKey2, accountIDLocation));
-        assertTrue(store.has(eKey3, accountIDLocation));
+        assertTrue(String.format("Auth token %s not found", SAMPLE_AUTH_TOKEN), store.has(eKey1, accountIDLocation));
+        assertTrue(String.format("Auth token %s not found", SAMPLE_AUTH_TOKEN2), store.has(eKey2, accountIDLocation));
+        assertTrue(String.format("Auth token %s not found", SAMPLE_AUTH_TOKEN3), store.has(eKey3, accountIDLocation));
 
         assertEquals(SAMPLE_AUTH_TOKEN_VERSION, store.get(eKey1, accountIDLocation).getValue());
         assertEquals(SAMPLE_AUTH_TOKEN_VERSION, store.get(eKey2, accountIDLocation).getValue());
@@ -271,7 +266,7 @@ public class TestSSDBEphemeralStore extends TestCase {
 
     @Test
     public void testAuthTokenExpiration() throws Exception {
-        Assume.assumeTrue(SSDBStoreConfigured);
+        TestUtil.assumeTrue("SSDB backend is not configured", SSDBStoreConfigured);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account",  ACCOUNT_ID}; }
@@ -287,7 +282,7 @@ public class TestSSDBEphemeralStore extends TestCase {
 
     @Test
     public void testDeleteAuthToken() throws Exception {
-        Assume.assumeTrue(SSDBStoreConfigured);
+        TestUtil.assumeTrue("SSDB backend is not configured", SSDBStoreConfigured);
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override
             public String[] getLocation() { return new String[] { "account",  ACCOUNT_ID}; }
@@ -303,7 +298,7 @@ public class TestSSDBEphemeralStore extends TestCase {
 
     @Test
     public void testDeleteLastLogon() throws Exception {
-        Assume.assumeTrue(SSDBStoreConfigured);
+        TestUtil.assumeTrue("SSDB backend is not configured", SSDBStoreConfigured);
         String lastLogon = "20160912212057.178Z";
         EphemeralLocation accountIDLocation = new EphemeralLocation() {
             @Override


### PR DESCRIPTION
- Updated tests to use assumptions instead of `if` statements
- Updated setUp method to test validity of the backend URL
- Removed flushdb() call in tearDown method. The `flushdb`operation hangs my SSDB instance, even when invoked via command line. Not sure how common this issue is, but either way it's probably not wise to use `flushdb` to clear test data because it clears _all_ data in the db, which may include attributes unrelated to the test run. Instead, the tests keep track of keys added to ssdb; these keys are then deleted on-by-one in the tearDown method.