### PR TITLE
Bugfix/zcs 3378

### DIFF
--- a/src/java-test/com/zimbra/ssdb/SSDBEphemeralStoreTest.java
+++ b/src/java-test/com/zimbra/ssdb/SSDBEphemeralStoreTest.java
@@ -80,7 +80,6 @@ public class SSDBEphemeralStoreTest {
             public String[] getLocation() { return new String[] { "cos", "47e456be-b00a-465e-a1db-4b53e64fa" }; }
         };
         expect(mockJedisPool.getResource()).andReturn(jedis).atLeastOnce();
-        expect(jedis.ping()).andReturn(null);
         expect(jedis.get("cos|47e456be-b00a-465e-a1db-4b53e64fa|somekey")).andReturn(null);
         jedis.close();
         replay(mockJedisPool);
@@ -103,7 +102,6 @@ public class SSDBEphemeralStoreTest {
             public String[] getLocation() { return new String[] { "cos", "47e456be-b00a-465e-a1db-4b53e64fa" }; }
         };
         expect(mockJedisPool.getResource()).andReturn(jedis).atLeastOnce();
-        expect(jedis.ping()).andReturn(null);
         expect(jedis.del("cos|47e456be-b00a-465e-a1db-4b53e64fa|someattr")).andReturn(null);
         jedis.close();
         replay(mockJedisPool);
@@ -128,7 +126,6 @@ public class SSDBEphemeralStoreTest {
             public String[] getLocation() { return new String[] { "domain", "47e456be-b00a-465e-a1db-4b53e64fa" }; }
         };
         expect(mockJedisPool.getResource()).andReturn(jedis).atLeastOnce();
-        expect(jedis.ping()).andReturn(null);
         expect(jedis.set("domain|47e456be-b00a-465e-a1db-4b53e64fa|testK|testD","testV|")).andReturn("testK");
         jedis.close();
         replay(mockJedisPool);
@@ -156,7 +153,6 @@ public class SSDBEphemeralStoreTest {
         };
         expect(mockJedisPool.getResource()).andReturn(jedis).atLeastOnce();
         String val = String.format("testV|%s", exp.getMillis());
-        expect(jedis.ping()).andReturn(null);
         expect(jedis.setex("domain|47e456be-b00a-465e-a1db-4b53e64fa|testK|testD",ttl,val)).andReturn("testK");
         jedis.close();
         replay(mockJedisPool);
@@ -180,7 +176,6 @@ public class SSDBEphemeralStoreTest {
             public String[] getLocation() { return new String[] { "domain", "47e456be-b00a-465e-a1db-4b53e64fa" }; }
         };
         expect(mockJedisPool.getResource()).andReturn(jedis).atLeastOnce();
-        expect(jedis.ping()).andReturn(null);
         expect(jedis.set("domain|47e456be-b00a-465e-a1db-4b53e64fa|testK","testV|")).andReturn("testK");
         jedis.close();
         replay(mockJedisPool);

--- a/src/java-test/com/zimbra/ssdb/SSDBEphemeralStoreTest.java
+++ b/src/java-test/com/zimbra/ssdb/SSDBEphemeralStoreTest.java
@@ -80,6 +80,7 @@ public class SSDBEphemeralStoreTest {
             public String[] getLocation() { return new String[] { "cos", "47e456be-b00a-465e-a1db-4b53e64fa" }; }
         };
         expect(mockJedisPool.getResource()).andReturn(jedis).atLeastOnce();
+        expect(jedis.ping()).andReturn(null);
         expect(jedis.get("cos|47e456be-b00a-465e-a1db-4b53e64fa|somekey")).andReturn(null);
         jedis.close();
         replay(mockJedisPool);
@@ -102,6 +103,7 @@ public class SSDBEphemeralStoreTest {
             public String[] getLocation() { return new String[] { "cos", "47e456be-b00a-465e-a1db-4b53e64fa" }; }
         };
         expect(mockJedisPool.getResource()).andReturn(jedis).atLeastOnce();
+        expect(jedis.ping()).andReturn(null);
         expect(jedis.del("cos|47e456be-b00a-465e-a1db-4b53e64fa|someattr")).andReturn(null);
         jedis.close();
         replay(mockJedisPool);
@@ -126,6 +128,7 @@ public class SSDBEphemeralStoreTest {
             public String[] getLocation() { return new String[] { "domain", "47e456be-b00a-465e-a1db-4b53e64fa" }; }
         };
         expect(mockJedisPool.getResource()).andReturn(jedis).atLeastOnce();
+        expect(jedis.ping()).andReturn(null);
         expect(jedis.set("domain|47e456be-b00a-465e-a1db-4b53e64fa|testK|testD","testV|")).andReturn("testK");
         jedis.close();
         replay(mockJedisPool);
@@ -153,6 +156,7 @@ public class SSDBEphemeralStoreTest {
         };
         expect(mockJedisPool.getResource()).andReturn(jedis).atLeastOnce();
         String val = String.format("testV|%s", exp.getMillis());
+        expect(jedis.ping()).andReturn(null);
         expect(jedis.setex("domain|47e456be-b00a-465e-a1db-4b53e64fa|testK|testD",ttl,val)).andReturn("testK");
         jedis.close();
         replay(mockJedisPool);
@@ -176,6 +180,7 @@ public class SSDBEphemeralStoreTest {
             public String[] getLocation() { return new String[] { "domain", "47e456be-b00a-465e-a1db-4b53e64fa" }; }
         };
         expect(mockJedisPool.getResource()).andReturn(jedis).atLeastOnce();
+        expect(jedis.ping()).andReturn(null);
         expect(jedis.set("domain|47e456be-b00a-465e-a1db-4b53e64fa|testK","testV|")).andReturn("testK");
         jedis.close();
         replay(mockJedisPool);

--- a/src/java/com/zimbra/ssdb/SSDBEphemeralStore.java
+++ b/src/java/com/zimbra/ssdb/SSDBEphemeralStore.java
@@ -258,7 +258,7 @@ public class SSDBEphemeralStore extends EphemeralStore {
             throw wrapJedisException(e);
         }
     }
-    static JedisPool getPool(String url) throws ServiceException {
+    private static JedisPool getPool(String url) throws ServiceException {
         String host;
         Integer port;
         String[] tokens = url.split(":");

--- a/src/java/com/zimbra/ssdb/SSDBEphemeralStore.java
+++ b/src/java/com/zimbra/ssdb/SSDBEphemeralStore.java
@@ -54,8 +54,9 @@ public class SSDBEphemeralStore extends EphemeralStore {
         setAttributeEncoder(new SSDBAttributeEncoder());
     }
     private Jedis getResource() throws ServiceException {
-        Jedis jedis = pool.getResource();
+        Jedis jedis;
         try{
+            jedis = pool.getResource();
             jedis.ping();
         } catch (JedisException e) {
             pool.destroy();

--- a/src/java/com/zimbra/ssdb/SSDBEphemeralStore.java
+++ b/src/java/com/zimbra/ssdb/SSDBEphemeralStore.java
@@ -296,6 +296,10 @@ public class SSDBEphemeralStore extends EphemeralStore {
                 return jedisMethod();
             } catch (JedisException e) {
                 try {
+                    /* Jedis throws an exception when connections in the pool go stale.
+                     * Since there is no way to test a connection without trying to send data
+                     * this code makes one attempt to retry a failed request. 
+                     */
                     pool.destroy();
                     pool = getPool(url);
                     return jedisMethod();


### PR DESCRIPTION
Updated SSDB adapter to handle stale Jedis connections. 
Verified the fix by running 10u/10K AuthRequests test in loadtest lab. 
In the updated fix, instead of sending 'ping' to SSDB before every request to make sure that the connection pool is still valid, SSDBEphemeralStore simply attempts to resend the failed request one more time after recreating the connection pool.