### PR TITLE
ZCS-12948: LC.ssdb_zok_compat? Double-double quote!

### DIFF
--- a/src/java/com/zimbra/ssdb/SSDBValueEncoder.java
+++ b/src/java/com/zimbra/ssdb/SSDBValueEncoder.java
@@ -20,7 +20,7 @@ public class SSDBValueEncoder extends ValueEncoder {
 
         Long expires = input.getExpiration();
         String value = input.getValue().toString();
-		String encoded;
+        String encoded;
 
         if (expires != null && expires > 0L) {
             encoded = String.format("%s|%s", value, String.valueOf(expires));
@@ -28,16 +28,16 @@ public class SSDBValueEncoder extends ValueEncoder {
             encoded = String.format("%s|", value);
         }
 
-		if (!LC.ssdb_zok_compat.booleanValue()) {
-			return encoded;
-		}
+        if (!LC.ssdb_zimbrax_compat.booleanValue()) {
+            return encoded;
+        }
 
-		if (encoded.startsWith("{") || encoded.startsWith("[")) {
-			// Already a JSON object
-			return encoded;
-		}
+        if (encoded.startsWith("{") || encoded.startsWith("[")) {
+            // Already a JSON object
+            return encoded;
+        }
 
-		// Wrap in double-quotes b/c ZOK expects a JSON string.
-		return String.format("\"%s\"", encoded);
+        // Wrap in double-quotes b/c ZOK expects a JSON string.
+        return String.format("\"%s\"", encoded);
     }
 }


### PR DESCRIPTION
ZOK transcodes JSON as part of its Redisson-based implementation, whereas Classic just writes and expects to read plain old strings. If `LC.ssdb_zok_compat=true`, then wrap simple string values in double quotes before they go into the store.  Goes with [this other pull request](https://github.com/Zimbra/zm-mailbox/pull/1467) that fixes reading JSON-formatted strings.

Maybe shouldn't use the LC field directly to avoid version conflicts for the extension? I think there's a generic getter somewhere that accepts a string and wouldn't throw an undefined field exception if the extension is used with an older Zimbra.